### PR TITLE
fix #3, workaround to fix exit early bug, caused by incorrect total time from corrupted file

### DIFF
--- a/libv2m/v2mplayer.cpp
+++ b/libv2m/v2mplayer.cpp
@@ -405,7 +405,7 @@ uint32_t V2MPlayer::Length()
 
 bool V2MPlayer::IsPlaying()
 {
-  return (m_base.valid && m_state.state == PlayerState::PLAYING) && ((m_base.maxtime * m_base.timediv) > m_state.cursmpl);
+  return m_base.valid && m_state.state == PlayerState::PLAYING;
 }
 
 


### PR DESCRIPTION
fix #3, workaround to fix exit early bug, caused by incorrect total time from corrupted file